### PR TITLE
Fix 'Published at' -> 'Published'

### DIFF
--- a/app/components/Metadata.tsx
+++ b/app/components/Metadata.tsx
@@ -26,7 +26,7 @@ export default function Metadata({ pkg, version }: { pkg: SerializeFrom<Package>
           {pkg.published_time
             ? (
               <p>
-                Published at
+                Published
                 {' '}
                 <Time time={pkg.published_time} />
               </p>

--- a/app/routes/package.$package.($version).tsx
+++ b/app/routes/package.$package.($version).tsx
@@ -109,7 +109,7 @@ export default function Package() {
                           {files.length > 0
                             ? (
                               <span className="text-sm text-slate-400">
-                                Published at
+                                Published
                                 {' '}
                                 <Time time={files.map(file => dayjs(file.upload_time)).sort((a, b) => a.diff(b))[0]} />
                               </span>


### PR DESCRIPTION
The "at" should be removed from the metadata card at the top left and the list of versions:

<img width="1453" alt="image" src="https://github.com/frostming/oven/assets/1324225/b43965a1-262e-479d-969c-05f3853366e3">

https://oven.fming.dev/package/pepotron?tab=versions

For example:

"Published at 5 days ago" -> "Published 5 days ago"

