### PR TITLE
Move gap between icon and text

### DIFF
--- a/app/routes/package.$package.($version).tsx
+++ b/app/routes/package.$package.($version).tsx
@@ -77,7 +77,7 @@ export default function Package() {
               {`${Object.keys(pkg.releases).length} Versions`}
             </TabsTrigger>
             <TabsTrigger value="files" className="flex-grow">
-              <SvgIcon name="tree" className="w-4 h-4 ml-1" />
+              <SvgIcon name="tree" className="w-4 h-4 mr-1" />
               Files
             </TabsTrigger>
           </TabsList>


### PR DESCRIPTION
For example: https://oven.fming.dev/package/pillow

The first two tabs have `margin-right: 4px` on the SVG icon, but the third has a `margin-left: 4px` on the icon, meaning there's no gap between them.

<img width="1044" alt="image" src="https://github.com/frostming/oven/assets/1324225/a4653fc5-5377-44bf-afb7-07cd5289f5ba">

Use the same "margin right" `mr-1` class for all.